### PR TITLE
Adding support for exponent / ** operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Following are the operators which can be overloaded with the desired overload fu
 | 38 | &= | __andAssign | Assignment |
 | 39 | \|= | __orAssign | Assignment |
 | 40 | ^= | __xorAssign | Assignment |
+| 41 | `**` | __exponent | Binary |
 
 
 ##Design Consideration / Very IMP / Must Read##

--- a/lib/overload.js
+++ b/lib/overload.js
@@ -43,7 +43,8 @@ var funcNames = {
     '>>>=': '__zeroFillRightShiftAssign',
     '&=': '__andAssign',
     '|=': '__orAssign',
-    '^=': '__xorAssign'
+    '^=': '__xorAssign',
+    '**': '__exponent'
 };
 
 //The AST Walker And Transformer
@@ -353,6 +354,9 @@ cons.forEach(function (constructor) {
     defineDefaultProp(constructor, funcNames['^='], function (o) {
         return o ^= this;
     });
+    defineDefaultProp(constructor, funcNames['**'], function (o) {
+        return o ** this;
+    });	
 });
 /* jshint ignore:end */
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   "homepage": "https://github.com/kushal-likhi/operator-overloading-js",
   "dependencies": {
     "escodegen": "^1.4.1",
-    "esprima": "^1.2.2"
+    "esprima": "^4.0.1"
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -42,6 +42,13 @@ describe('Operator overloading Test Suite', function () {
             done();
         });
 
+        it('should overload ** operator', function (done) {
+            overload(function () {
+                assertEqual((33 ** 22), '33**22');
+            })();
+            done();
+        });
+
         it('should overload - operator', function (done) {
             overload(function () {
                 assertEqual((33 - 22), '33-22');


### PR DESCRIPTION
Adding support for exponent / ** operator

Required updating esprima package to latest 